### PR TITLE
Supported platforms

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -5,6 +5,9 @@ navigation:
       - title: What is Ubuntu Core?
         location: index.md
 
+      - title: Supported platforms
+        location: platforms.md
+
       - title: Snaps in Ubuntu Core
         location: coresnaps.md
 

--- a/docs/en/platforms.md
+++ b/docs/en/platforms.md
@@ -1,0 +1,32 @@
+---
+title: Ubuntu IoT Developer Documentation
+---
+
+# Supported platforms
+
+Ubuntu Core runs on a large range of hardware, and pre-built images are available
+for specific reference platforms. These images are a great way to quickly get
+started with Ubuntu Core on a Raspberry Pi, for example, or to explore Ubuntu
+Core's features and evaluate its potential.
+
+Canonical produces official images for the following platforms:
+
+| Platform              | Hardware/CPU | Cores | Memory    | Storage   |
+|-----------------------|----------|-----------|-----------|-----------|
+| Raspberry Pi 2        | Broadcom BCM2836 ARM Cortex-A7 | 4 | 1 GB | Not built-in |
+| Raspberry Pi 3        | Broadcom BCM2837 ARM Cortex-A53 64-bit | 4 | 1 GB | Not built-in |
+| Raspberry Pi CM 3 | Broadcom BCM2837 ARM Cortex-A53 64-bit | 4 | 1 GB  | Not built-in |
+| Raspberry Pi 4        | Broadcom BCM2711 Cortex-A72 (ARM v8) 64-bit | 4 | 1/2/4 GB | Not built-in |
+| Orange Pi Zero         | ARM H2 Cortex-A7 64-bit | 4 | 256/512 MB | Not built-in |
+| Qualcomm Snapdragon 410c | ARM Cortex A53 64-bit | 4 |  1 GB | 8 GB eMMC on-board flash storage |
+| Intel NUC             | Intel Core i3, i5, i7 64-bit | >8| >32 GB | Not built-in |
+| Samsung Artik 5       | ARM Cortex-A7 64-bit | 2/4 | 512 MB/1 GB | 4 GB eMMC on-board flash storage |
+| Samsung Artik 10      | ARM Cortex-A15 + Quad Cortex-A7 64-bit | 4 | 2 GB | 16 GB eMMC on-board flash storage |
+| KVM                   | Full x86 32/64 bit CPU virtualisation | as defined | as defined | as defined |
+
+Images are available from
+[http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/](http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/)
+
+Ubuntu community members also work with, and produce, images for other
+platforms and CPUs. Refer to these individual projects for more information on
+what other unofficial images might work for your use cases.


### PR DESCRIPTION
New doc outlining which Ubuntu Core platforms have images. This page will be updated to include links to:
- building an image
- installing and testing a supported image (on a Raspberry Pi)

Those two docs are being worked on now.