### PR TITLE
updated yarn requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-ubuntudesign.documentation-builder==1.5.0
+ubuntudesign.documentation-builder==1.6.2
+gitdb2==3.0.1


### PR DESCRIPTION
for documentation-builder, and also gitdb2 to hopefully solve `No module named gitdb.utils.compat error.`