### PR TITLE
Configuration for core.docs.ubuntu.com

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -1,0 +1,20 @@
+domain: core.docs.ubuntu.com
+
+image: prod-comms.docker-registry.canonical.com/core.docs.ubuntu.com
+
+readinessPath: "/"
+
+# Overrides for production
+production:
+  replicas: 5
+
+  nginxConfigurationSnippet: |
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+
+# Overrides for staging
+staging:
+  replicas: 3
+
+  nginxConfigurationSnippet: |
+    more_set_headers "X-Robots-Tag: noindex";
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";


### PR DESCRIPTION
## Done

- K8s configuration for core.docs.ubuntu.com. Fixes https://github.com/canonical-web-and-design/web-squad/issues/2966
- Pushed new docker image `prod-comms.docker-registry.canonical.com/core.docs.ubuntu.com`

## QA
Edit your microk8s secret keys to include this new site:
`microk8s.kubectl edit secret secret-keys`
It should look like:
```yaml
data:
  core-docs-ubuntu-com: cXMzbUJ5eFp3ZVBabkxUdFVadTJ1emFYb0NhdExkTW9nS0I0V1R6bg==
```
Then run:
`konf production deploy/site.yaml --local-qa | microk8s.kubectl apply -f -`
Check that everything is fine
`microk8s.kubectl get pods`
Edit your `/etc/hosts` file to point `core.docs.ubuntu.com` to your local machine and check the site
