### PR TITLE
Remove core from URL path

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,3 +1,3 @@
-~^/(core/?|en/?|core/en)?$ /core/en/;
-/core/en/guides/build-device/assertions /core/en/reference/assertions;
+~^/(core/?|core/en)?$ /en/;
+/en/guides/build-device/assertions /en/reference/assertions;
 


### PR DESCRIPTION
## Done

- Remove `/core` from URL

## QA

1. `docker build --build-arg COMMIT_ID=test --tag core-docs:test .`
2. `docker run -ti -p 80:80 core-docs:test`
3. Go to http://localhost and check everything is fine and the final URL is `http://localhost/en/` instead of `http://localhost/core/en/`