### PR TITLE
Fix search

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This documentation will walk you through the steps of building and managing
 an Ubuntu Core device.
 
-You can find it published on [docs.ubuntu.com/core](http://docs.ubuntu.com/core).
+You can find it published on [core.docs.ubuntu.com](http://core.docs.ubuntu.com/).
 
 # Building
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle .repo en .extra; yarn run clean-git-repos",
     "watch": "watch -p 'docs/**/*.md' -c 'yarn run build-docs'",
     "build-repo": "git config --global user.email 'you@example.com' && git config --global user.name 'Your Name' && git config --global color.ui false && ./bin/repo --trace  init --manifest-url \"$(./bin/get-manifest-url)\" --manifest-branch \"$(git rev-parse HEAD)\" && ./bin/repo sync",
-    "build-docs": "documentation-builder --template-path template.html --base-directory docs --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.ubuntu.com/core' --search-url '/search' --search-placeholder 'Search Ubuntu Core docs' --no-link-extensions",
+    "build-docs": "documentation-builder --template-path template.html --base-directory docs --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'core.docs.ubuntu.com' --search-url 'https://ubuntu.com/search' --search-placeholder 'Search Ubuntu Core docs' --no-link-extensions",
     "build": "yarn run build-repo && yarn run build-docs"
   },
   "dependencies": {


### PR DESCRIPTION
## Done

- Fix search bar to use ubuntu.com, same way docs.ubuntu.com is doing.
## QA
1. `./run build`
1. `docker build --build-arg COMMIT_ID=test --tag core-docs:test .`
2. `docker run -ti -p 80:80 core-docs:test`
3. Go to http://localhost , use the search bar and check that that you get results.

## Issue

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3164
