### PR TITLE
Correct error in `snaps` header docs for uc20

### DIFF
--- a/docs/en/releases/uc20.md
+++ b/docs/en/releases/uc20.md
@@ -72,8 +72,9 @@ A new header to control which snaps comprise the device setup. It consists of
 the following keywords and mappings:
 
 - `name` _(mandatory)_: name of the snap. Cross-checked at image build time but ignored later
-- `type` _(mandatory)_:  snap-id, needs to be either: `base|gadget|kernel|app|core`.
+- `type` _(mandatory)_: type of the snap, needs to be either: `base|gadget|kernel|app|core`.
   _app_ is the default
+- `id` _(optional)_: id of the snap if assigned by a store. Must be omitted for local snaps.
 - `modes` _(optional)_: a list with UC20 modes (verbs, "run") or mode aliases ("ephemeral",
   covers all recovery/tmpfs modes) for which the snap needs to be installed.
 Default is _[run]_, should not be used for types `kernel|gadget` and for the

--- a/docs/en/releases/uc20.md
+++ b/docs/en/releases/uc20.md
@@ -72,7 +72,7 @@ A new header to control which snaps comprise the device setup. It consists of
 the following keywords and mappings:
 
 - `name` _(mandatory)_: name of the snap. Cross-checked at image build time but ignored later
-- `id` _(mandatory)_:  snap-id, needs to be either: `base|gadget|kernel|app|core`.
+- `type` _(mandatory)_:  snap-id, needs to be either: `base|gadget|kernel|app|core`.
   _app_ is the default
 - `modes` _(optional)_: a list with UC20 modes (verbs, "run") or mode aliases ("ephemeral",
   covers all recovery/tmpfs modes) for which the snap needs to be installed.


### PR DESCRIPTION
This lists the keywords/mappings for the new model definition header `snaps`. I think the line for `id` actually describes the key `type`, which is missing from this listing, but can be seen in the example UC20 model definition.