### PR TITLE
Add info about serial-authority header in model.md #1

### DIFF
--- a/docs/en/reference/assertions/model.md
+++ b/docs/en/reference/assertions/model.md
@@ -15,9 +15,10 @@ authority-id:      <authority account id>
 revision:          <int>
 series             <string>
 brand-id           <account id>
+serial-authority   <list<string>> # optional list of serial authorities. Use “generic” to have the snap store generate a serial.
 model              <model id>
-classic            <true|false>
-store              <string>
+classic            <true|false> # optional
+store              <string> # optional
 display-name       <descriptive string>
 architecture       <debian architecture name>
 gadget             <gadget snap name>


### PR DESCRIPTION
As pointed out by @ogra1 on [IRC](https://irclogs.ubuntu.com/2020/11/11/%23snappy.txt) (at 12:47), this header allows custom gadget images to receive a generic serial from the Ubuntu snap store. This will 
1. prevent misleading errors for `initialize device` in `snap changes` if the gadget's `register-device` hook does nothing
2. allow for proper statistics in the snap store dashboard, as the Weekly Active Devices are counted based on their serial

This is helpful for pre-production tinkering or open source projects that distribute custom images without a custom serial vault.

Also adds `# optional` info to other optional headers.