### PR TITLE
Redirect core docs to ubuntu.com/core/docs

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,3 +1,4 @@
 ~^/(core/?|core/en)?$ /en/;
 /en/guides/build-device/assertions /en/reference/assertions;
-
+# redirect to new ubuntu.com/core/docs
+~^/(en/|/en/)?$ https://ubuntu.com/core/docs;


### PR DESCRIPTION
## Summary

Redirect to ubuntu.com/core/docs

## QA
- Checkout this branch and pull down this source code
- Build docker image: `docker build --tag core-docs .`
- Run docker image: `docker run -ti core-docs -p 8207:8207`
- Go to localhost:8207 and make sure it redirects to ubuntu.com/core/docs

## Issue
Fixes #https://github.com/canonical-web-and-design/web-squad/issues/3780